### PR TITLE
Disallow quoted predicates in check-arg

### DIFF
--- a/srfi/impl.gauche.scm
+++ b/srfi/impl.gauche.scm
@@ -29,8 +29,6 @@
                  procedure? rational? string? symbol? keyword? vector?
 
                  <integer> <boolean> <char> <complex> <real> <pair> <number> <null> <procedure> <rational> <string> <symbol> <keyword> <vector>)
-    ((_ (quote pred) val . rest)
-     (check-arg pred val))
     ((_ integer? val . rest)
      (assume (is-a? val <integer>) "type mismatch" <integer> val . rest))
     ((_ exact-integer? val . rest)
@@ -64,4 +62,4 @@
     ((_ vector? val . rest)
      (assume (is-a? val <vector>) "type mismatch" <vector> val . rest))
     ((_ pred val . rest)
-     (assume (pred val) "argument should match the specification"  '(pred val) . rest))))
+     (assume (pred val) "argument should match the specification" '(pred val) . rest))))

--- a/srfi/impl.generic.scm
+++ b/srfi/impl.generic.scm
@@ -42,8 +42,6 @@
 
 (define-syntax check-arg
   (syntax-rules ()
-    ((_ (quote pred) val . rest)
-     (check-arg pred val))
     ((_ pred val . rest)
      (assume (pred val) "argument should match the specification"  '(pred val) val . rest))))
 

--- a/srfi/impl.stklos.scm
+++ b/srfi/impl.stklos.scm
@@ -29,8 +29,6 @@
                  procedure? rational? string? symbol? keyword? vector?
 
                  <boolean> <char> <complex> <real> <pair> <number> <null> <procedure> <rational> <string> <symbol> <keyword> <vector>)
-    ((_ (quote pred) val . rest)
-     (check-arg pred val))
     ((_ integer? val . rest)
      (assume (is-a? val <integer>) "type mismatch" . rest))
     ((_ exact-integer? val . rest)


### PR DESCRIPTION
I initially implemented as a convenience, but ended up never using it. It's also meaningless, because functions can be passed through the regular value infrastructure in Scheme (compared with Common Lisp and other Lisp-2 dialects where functions often need quoted symbols as proxies.)