### PR TITLE
Pass more WHO to check-arg everywhere.

### DIFF
--- a/srfi/impl.chicken.scm
+++ b/srfi/impl.chicken.scm
@@ -61,7 +61,7 @@
     ((_ (vector?) value)      (let ((v value)) (check-arg vector? v) (the vector v)))
     ((_ (predicate) value)
      (let ((v value))
-       (check-arg predicate v)
+       (check-arg predicate v 'values-checked)
        v))
     ((_ (predicate ...) value ...)
      (values (return-checked (predicate) value) ...))))

--- a/srfi/impl.generic.scm
+++ b/srfi/impl.generic.scm
@@ -51,7 +51,7 @@
   (syntax-rules ()
     ((_ (predicate) value)
      (let ((v value))
-       (check-arg predicate v)
+       (check-arg predicate v 'values-checked)
        v))
     ((_ (predicate ...) value ...)
      (values (values-checked (predicate) value) ...))))
@@ -146,7 +146,9 @@
            (args-so-far ...) (checks-so-far ...) (body ...) (arg pred) . args)
         (%case-lambda-checked
          (clauses-so-far ...) (clauses-to-process ...)
-         (args-so-far ... arg) (checks-so-far ... (check-arg pred arg)) (body ...) . args))
+         (args-so-far ... arg)
+         (checks-so-far ... (check-arg pred arg 'case-lambda-checked))
+         (body ...) . args))
        ((_ (clauses-so-far ...) (clauses-to-process ...)
            (args-so-far ...) (checks-so-far ...) (body ...) arg . args)
         (%case-lambda-checked

--- a/srfi/impl.kawa.scm
+++ b/srfi/impl.kawa.scm
@@ -52,7 +52,7 @@
     ((_ (output-port?) value) (as output-port value))
     ((_ (predicate) value)
      (let ((v value))
-       (check-arg predicate v)
+       (check-arg predicate v 'values-checked)
        v))
     ((_ (predicate ...) value ...)
      (values (return-checked (predicate) value) ...))))


### PR DESCRIPTION
Supports a suggestion for `who' argument the SRFI is proposing.