### PR TITLE
Only throw errors when in debug mode

### DIFF
--- a/srfi-253.html
+++ b/srfi-253.html
@@ -162,6 +162,11 @@ SPDX-License-Identifier: MIT
 </p>
 
 <p>
+  Note that all the provided macros/procedures only throw checking errors in debug mode!
+  All the checking is disabled if the <code>debug</code> feature is not provided!
+</p>
+
+<p>
   Notice that <a href="#use-case-4">(4)</a> is explicitly not covered by this SRFI.
   See <a href="#design--match-over-check-case">(Design decisions) match&amp;predicates > check-case</a> for why.
 </p>

--- a/srfi/impl.generic.scm
+++ b/srfi/impl.generic.scm
@@ -29,11 +29,16 @@
     (syntax-rules ()
       ((_ expr . rest)
        (assert expr)))))
+ (debug
+  (define-syntax assume
+    (syntax-rules ()
+      ((_ expr . rest)
+       (or expr
+           (error "assumption violated" 'expr . rest))))))
  (else (define-syntax assume
          (syntax-rules ()
-           ((_ expr . rest)
-            (or expr
-                (error "assumption violated" 'expr . rest)))))))
+           ((_ . rest)
+            #t)))))
 
 (cond-expand
  (guile


### PR DESCRIPTION
This makes reference implementation only throw errors when in debug mode. Also adds a note in the document. 