### PR TITLE
Reword that `values-checked` guarantees the return values.

### DIFF
--- a/srfi-253.html
+++ b/srfi-253.html
@@ -197,7 +197,8 @@ SPDX-License-Identifier: MIT
 <h3 id="spec--values-checked">(values-checked (predicates ...) values ...)</h3>
 
 <p>
-  Checks <code>values</code> with <code>predicates</code> (the number of values and predicates should match) and returns them as multiple values.
+  Guarantees that the <code>values</code> abide by the given <code>predicates</code>
+  (the number of values and predicates should match) and returns them as multiple values.
   If any of the <code>predicates</code> returned false, signals an error.
   Might coerce the values when the types are compatible (e.g. int -> float.)
   Supports multiple values:

--- a/srfi-253.html
+++ b/srfi-253.html
@@ -200,7 +200,7 @@ SPDX-License-Identifier: MIT
   Guarantees that the <code>values</code> abide by the given <code>predicates</code>
   (the number of values and predicates should match) and returns them as multiple values.
   If any of the <code>predicates</code> returned false, signals an error.
-  Might coerce the values when the types are compatible (e.g. int -> float.)
+  Implementations may choose to coerce the values when the types are compatible (e.g. integer -> inexact).
   Supports multiple values:
 </p>
 


### PR DESCRIPTION
This makes the wording more consistent with coercion behavior.