### PR TITLE
Use "it is an error" more.

### DIFF
--- a/srfi-253.html
+++ b/srfi-253.html
@@ -174,8 +174,8 @@ SPDX-License-Identifier: MIT
 <h3 id="spec--check-arg">(check-arg predicate value . args)</h3>
 
 <p>
-  Checks whether the <code>value</code> conforms to the <code>predicate</code>.
-  If <code>predicate</code> returns false when called on <code>value</code>, signals an error.
+  Guarantees (to all the code following it) that the <code>value</code> conforms to the <code>predicate</code>.
+  It is an error if <code>predicate</code> returns false when called on <code>value</code>.
   Implementations may use <code>args</code> in any non-portable way, but are advised to follow the convention of passing the who/caller as third argument.
 </p>
 
@@ -204,7 +204,7 @@ SPDX-License-Identifier: MIT
 <p>
   Guarantees that the <code>values</code> abide by the given <code>predicates</code>
   (the number of values and predicates should match) and returns them as multiple values.
-  If any of the <code>predicates</code> returned false, signals an error.
+  It is an error if any of the <code>predicates</code> returned false.
   Implementations may choose to coerce the values when the types are compatible (e.g. integer -> inexact).
   Supports multiple values:
 </p>
@@ -239,7 +239,8 @@ SPDX-License-Identifier: MIT
 <h3 id="spec--let-checked">(let-checked ((name predicate [value]) ...) body ...)</h3>
 
 <p>
-  Ensures that, for the duration of the <code>body</code>, every <code>name</code> abides by the respective <code>predicate</code>.
+  Guarantees that, for the duration of the <code>body</code>, every <code>name</code> abides by the respective <code>predicate</code>.
+  (It is an error otherwise.)
   Supports lists as <code>name</code> and <code>predicate</code>, allowing for multiple checked values.
   Binds symbols in the order of appearance, with all the defined bindings available to the bindings following them.
   Technically, should've been called <code>let*-values-checked</code>, but that would be too much, thus <code>let-checked</code>.
@@ -263,7 +264,8 @@ SPDX-License-Identifier: MIT
 
 <p>
   A regular lambda, but with any argument (except the rest argument) optionally having the form <code>name</code> or the form <code>(name predicate)</code>.
-  Arguments of the latter form will be checked by the respective <code>predicate</code>.
+  Arguments of the latter form are guaranteed to satisfy the respective <code>predicate</code>.
+  It is an error if either of the arguments does not satisfy the predicate.
 </p>
 
 <pre role=code>
@@ -284,6 +286,7 @@ SPDX-License-Identifier: MIT
 <p>
   Defined in case <a href="https://srfi.schemers.org/srfi-227">SRFI-227</a> is accessible.
   Same as <code>opt-lambda</code>, but every optional argument with a specified value can also specify a predicate to check it with.
+  (It is an error if the check if unsuccessful.)
   The respective argument form is <code>(name default-value predicate)</code>.
   Only the optionals with default value can have predicates (to avoid ambiguity.)
 </p>
@@ -299,7 +302,7 @@ SPDX-License-Identifier: MIT
 <h3 id="spec--define-checked">(define-checked (name args ...) body ...) | (define-checked name predicate value)</h3>
 
 <p>
-  Defines a procedure or variable checked by the given predicates.
+  Defines a procedure or variable satisfying the given predicates.
   For procedures, effectively equal to <code>define+lambda-checked</code>:
 </p>
 


### PR DESCRIPTION
Implying that implementations should throw an error is too narrow, thus the new phrasing. Really, implementations have all the rights to fail in their own horrible ways.