### PR TITLE
srfi.sld: Fix the cond-expand for not chicken.

### DIFF
--- a/srfi/srfi.sld
+++ b/srfi/srfi.sld
@@ -41,7 +41,8 @@
     (import (scheme base)
             (scheme case-lambda))))
   (cond-expand
-   ((not chicken (library (srfi 227)))
+   ((and (not chicken)
+         (library (srfi 227)))
     (import (srfi 227))
     (export opt-lambda-checked define-optionals-checked))
    (else))


### PR DESCRIPTION
This fixes the broken condition that was mistakenly passing two args to `not`.

sls/sld are still terribly broken and useless, but that's a different problem.