### PR TITLE
Sample implementation: Full chicken and gauche support.

### DIFF
--- a/srfi-253.html
+++ b/srfi-253.html
@@ -333,6 +333,7 @@ SPDX-License-Identifier: MIT
       <li> Rest arguments are not supported.
       <li> <code>check-arg</code> shadows the syntax provided by <code>(gauche base)</code>...
       <li>... and makes additional type checks with Gauche object system.
+      <li> No SRFI-227 support yet.
     </ul>
   <li> Gambit: broken, undebugged due to insufficient understanding of the implementation
 </ul>


### PR DESCRIPTION
253.sld is still broken, but directly loading impl.scm works on both. `opt-lambda-checked` is not implemented on Gauche for now.