### PR TITLE
Use "it is an error" in define-record-type-checked section

### DIFF
--- a/srfi-253.html
+++ b/srfi-253.html
@@ -315,6 +315,7 @@ SPDX-License-Identifier: MIT
   <code>type-name</code>, <code>constructor</code>, and <code>predicate</code> are the same as R<sup>7</sup>RS <code>define-record-type</code>'s.
   Fields are either of the form <code>(field-name predicate accessor-name)</code> or <code>(field-name predicate accessor-name modifier-name)</code>.
   These ensure that accessor and modifier return checked data and check new data respectively.
+  <a href="#it-is-an-error">It is an error</a> if any of the checks are not successful.
 </p>
 
 <p>


### PR DESCRIPTION
Forgot to add this one.