### PR TITLE
Fix #prior references in TOC and elsewhere.

### DIFF
--- a/srfi-253.html
+++ b/srfi-253.html
@@ -50,7 +50,7 @@ SPDX-License-Identifier: MIT
       <li><a href="#implementation--check-arg-macro">check-arg—procedure or macro?</a>
     </ol>
   </li>
-  <li><a href="#prior-art">Prior Art</a>
+  <li><a href="#prior">Prior Art</a>
     <ol>
       <li><a href="#prior--conditionals">Guarding conditionals</a>
       <li><a href="#prior--check-x">Ad hoc checks: check-*</a>
@@ -143,7 +143,7 @@ SPDX-License-Identifier: MIT
 </dl>
 
 <p>
-  See the <a href="#prior-art">Prior art</a> section for more references and context.
+  See the <a href="#prior">Prior art</a> section for more references and context.
 </p>
 
 <p>


### PR DESCRIPTION
Let's declare a new draft after this is merged.