### PR TITLE
Only use Chicken's compiler-typecase when on csc.

### DIFF
--- a/srfi/impl.scm
+++ b/srfi/impl.scm
@@ -271,7 +271,7 @@
         (values (values-checked (predicate) value) ...))))))
 
 (cond-expand
- (chicken
+ (csc
   (define-syntax %check-case
     (syntax-rules (else
                    ;; Predicates


### PR DESCRIPTION
`compiler-typecase` is Chicken compiler (`csc`) specific, so it's not particularly correct to use it on Chicken interpreter (`csi`, falls under the `chicken` cond-expand.) This fix only defines `check-case` as `compiler-typecase` in compiler context, and not in interpreter one.