### PR TITLE
Even more involved example file

### DIFF
--- a/example.scm
+++ b/example.scm
@@ -2,7 +2,15 @@
  (guile
   (import (ice-9 rdelim))
   (define-checked (read-line (port port?))
-    (car (%read-line port)))))
+    (car (%read-line port))))
+ (csi
+  (import (chicken io)))
+ (csc
+  (import (chicken io)))
+ (else))
+
+(import (srfi 13))
+(import (srfi 1))
 
 (define (disjoin . predicates)
   (lambda (x)

--- a/example.scm
+++ b/example.scm
@@ -26,8 +26,6 @@
   (let ((in (open-input-file file-name)))
     (let lines ((acc (list))
                 (new-line (read-line in)))
-      (display new-line)
-      (newline)
       (if (eof-object? new-line)
           (values-checked ((list-of? string?))
                           (begin


### PR DESCRIPTION
This adds more code and comments to example.scm to make it represent the SRFI somewhat better. The only thing missing in the example by now is `define-record-type-checked`, but I'll leave it for later. Tested on Guile and Chicken, works like a charm!