### PR TITLE
Add tests for SRFI 273 return value checks

### DIFF
--- a/test.scm
+++ b/test.scm
@@ -134,6 +134,9 @@
 (test-assert ((lambda-checked (a (b integer?)) #t) "hello" 3))
 (test-error ((lambda-checked ((a integer?)) #t) "hello"))
 (test-error ((lambda-checked (a (b integer?)) #t) "hello" "hi"))
+;; SRFI 273 return value checks
+(test-assert ((lambda-checked ((b integer?)) => (integer?) 2) 1))
+(test-error ((lambda-checked ((b integer?)) => (integer?) #t) 1))
 ;; Rest args. Sample implementation doesn't reliably pass this.
 ;; (test-assert (lambda-checked (a . c) #t))
 ;; (test-assert (lambda-checked ((a integer?) . c) #t))
@@ -181,6 +184,23 @@
 (test-assert (checked-case-lambda 3 "hello"))
 (test-assert (checked-case-lambda "hi" "hello"))
 (test-error (checked-case-lambda 3 3 3))
+;; SRFI 273 return value checks
+(define good-return-checked-case-lambda
+  (case-lambda-checked
+   (() => (integer?) 1)
+   (((a integer?)) => (integer?) 1)
+   (args => (integer?) 1)))
+(test-assert (good-return-checked-case-lambda 1))
+(test-assert (good-return-checked-case-lambda))
+(test-assert (good-return-checked-case-lambda 1 2 3))
+(define bad-return-checked-case-lambda
+  (case-lambda-checked
+   (() => (integer?) #t)
+   (((a integer?)) => (integer?) #t)
+   (args => (integer?) #t)))
+(test-error (bad-return-checked-case-lambda 1))
+(test-error (bad-return-checked-case-lambda))
+(test-error (bad-return-checked-case-lambda 1 2 3))
 (test-end "case-lambda-checked")
 
 


### PR DESCRIPTION
Hello! I didn’t include these earlier because I didn’t think them important enough. But, as testing on multiple implementations shows, these tests are useful enough. Thus the PR including them.